### PR TITLE
return the globally defined object as the export.

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,3 +4,4 @@ global.window = {};
 require('fetch');
 global.fetch = global.window.fetch;
 global.window = noConflictWindow;
+module.exports = global.fetch;


### PR DESCRIPTION
this should allow you to...

```
var fetch = require('fetch');
```

...instead of relying on the implicit global.
