### PR TITLE
Fix handling of errors in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ require('isomorphic-fetch');
 
 fetch('https://offline-news-api.herokuapp.com/stories')
 	.then(function(response) {
-		if (response.status >= 400 || response.status < 600) {
+		if (response.status >= 400) {
 			throw new Error("Bad response from server");
 		}
 		return response.json();


### PR DESCRIPTION
The two limits should be used with AND (response.status >= 400 && response.status < 600) to get the correct range. With OR also 200 is an error.
But i think the upper limit can safely be removed, as if there is a status code >= 600 something is really wrong. And some special cases are already handled by fetch itself (see https://github.com/github/fetch/blob/master/fetch.js#L164)