### PR TITLE
Include Headers, Response and Request objects on the global scope on the server.

### DIFF
--- a/server.js
+++ b/server.js
@@ -5,4 +5,7 @@ var noConflictSelf = global.self;
 global.self = {};
 require('whatwg-fetch');
 global.fetch = global.self.fetch;
+global.Headers = global.self.Headers;
+global.Request = global.self.Request;
+global.Response = global.self.Response;
 global.self = noConflictSelf;


### PR DESCRIPTION
The client side version seems to expose these objects on global.  I haven't read the spec closely enough to know if they should be there, but that would be an upstream issue?