### PR TITLE
Fix module exports from Webpack / Browserify

### DIFF
--- a/npm-client.js
+++ b/npm-client.js
@@ -1,1 +1,6 @@
-module.exports = require('whatwg-fetch');
+// the whatwg-fetch polyfill installs the fetch() function
+// on the global object (window or self)
+//
+// Return that as the export for use in Webpack, Browserify etc.
+require('whatwg-fetch');
+module.exports = self.fetch;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isomorphic-fetch",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "Isomorphic WHATWG Fetch API, for Node & Browserify",
   "browser": "npm-client.js",
   "main": "server.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isomorphic-fetch",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "Isomorphic WHATWG Fetch API, for Node & Browserify",
   "browser": "npm-client.js",
   "main": "server.js",
@@ -10,14 +10,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/matthew-andrews/node-fetch.git"
+    "url": "https://github.com/matthew-andrews/isomorphic-fetch.git"
   },
   "author": "Matt Andrews <matt@mattandre.ws>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/matthew-andrews/node-fetch/issues"
+    "url": "https://github.com/matthew-andrews/isomorphic-fetch/issues"
   },
-  "homepage": "https://github.com/matthew-andrews/node-fetch",
+  "homepage": "https://github.com/matthew-andrews/isomorphic-fetch/issues",
   "dependencies": {
     "node-fetch": "^1.0.1",
     "whatwg-fetch": "matthew-andrews/fetch#ie9"


### PR DESCRIPTION
In Webpack / Browserify, require('isomorphic-fetch')
returned an empty object because the whatwg-fetch
polyfill only installs fetch() on the global object.

Also correct URLs in package.json

Fixes #16