### PR TITLE
Prevent Illegal invocation Error in webpack

### DIFF
--- a/npm-client.js
+++ b/npm-client.js
@@ -3,4 +3,4 @@
 //
 // Return that as the export for use in Webpack, Browserify etc.
 require('whatwg-fetch');
-module.exports = self.fetch;
+module.exports = self.fetch.bind(self);


### PR DESCRIPTION
I am using ES6 modules with webpack and I ran into an issue. My code was something like this:

```javascript
import fetch from 'isomorphic-fetch';

fetch(url)
  // .then do stuff
```

which raised an Illegal invocation Error. This is the same error that happens when you do something like this:

```javascript
log = console.log
log('hello'); // Error
```

I looked at the compiled code and it looked like this:

```javascript
var _fetch = __webpack_require__(10);
var _fetch2 = _interopRequireWildcard(_fetch);

_fetch2['default'](url);
```

which is the problem because now the fetch function is called with a this value of the _fetch2 module. It is similar to doing the following:

```javascript
var obj = {myFetch: fetch};

obj.myFetch(url); // Error
```

So I just made sure that fetch was bound to the window object on importing. This of course assumes that Function.bind exists or was polyfilled.