### PR TITLE
require('isomorphic-fetch/safe') to not set globals

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,5 @@
 {
   "node": true,
   "browser": true,
-  "predef": ["describe", "it", "before"]
+  "predef": ["describe", "it", "before", "after"]
 }

--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ fetch('//offline-news-api.herokuapp.com/stories')
 	});
 ```
 
+If you don't want a global:
+
+```js
+var fetch = require('isomorphic-fetch/safe');
+typeof global.fetch === 'undefined'
+```
+
 ## License
 
 All open source code released by FT Labs is licenced under the MIT licence.  Based on [the fine work by](https://github.com/github/fetch/pull/31) **[jxck](https://github.com/Jxck)**.

--- a/fetch-browser.js
+++ b/fetch-browser.js
@@ -3,4 +3,7 @@
 //
 // Return that as the export for use in Webpack, Browserify etc.
 require('whatwg-fetch');
-module.exports = self.fetch;
+var globalFetch = fetch;
+delete global.fetch;
+
+module.exports = globalFetch;

--- a/fetch-browser.js
+++ b/fetch-browser.js
@@ -1,9 +1,13 @@
 // the whatwg-fetch polyfill installs the fetch() function
 // on the global object (window or self)
-//
-// Return that as the export for use in Webpack, Browserify etc.
-require('whatwg-fetch');
-var globalFetch = fetch;
-delete global.fetch;
+var fetchWasDefined = 'fetch' in global;
+var originalGlobalFetch = global.fetch;
 
-module.exports = globalFetch;
+require('whatwg-fetch');
+module.exports = fetch;
+
+if (fetchWasDefined) {
+	global.fetch = originalGlobalFetch;
+} else {
+	delete global.fetch;
+}

--- a/fetch.js
+++ b/fetch.js
@@ -1,0 +1,6 @@
+module.exports = function(url, options) {
+	if (/^\/\//.test(url)) {
+		url = 'https:' + url;
+	}
+	return require('node-fetch').call(this, url, options);
+};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "isomorphic-fetch",
   "version": "0.0.0",
   "description": "Isomorphic WHATWG Fetch API, for Node & Browserify",
-  "browser": "npm-client.js",
+  "browser": {
+    "./fetch.js": "./fetch-browser.js"
+  },
   "main": "server.js",
   "scripts": {
     "files": "find . -name '*.js' ! -path './node_modules/*' ! -path './bower_components/*'",

--- a/safe.js
+++ b/safe.js
@@ -1,0 +1,2 @@
+'use strict';
+module.exports = require('./fetch');

--- a/server.js
+++ b/server.js
@@ -1,12 +1,6 @@
 "use strict";
 
-var realFetch = require('node-fetch');
-module.exports = function(url, options) {
-	if (/^\/\//.test(url)) {
-		url = 'https:' + url;
-	}
-	return realFetch.call(this, url, options);
-};
+module.exports = require('./fetch');
 
 if (!global.fetch) {
 	global.fetch = module.exports;

--- a/test/safe.test.js
+++ b/test/safe.test.js
@@ -1,0 +1,25 @@
+"use strict";
+var expect = require('chai').expect;
+
+describe('fetch/safe', function () {
+	var restoreGlobalFetch;
+	before(function () {
+		var globalFetch = global.fetch;
+		if (globalFetch) {
+			delete global.fetch;
+			restoreGlobalFetch = function () {
+				global.fetch = globalFetch;
+			};
+		}
+	});
+	after(function () {
+		if (typeof restoreGlobalFetch === 'function') {
+			restoreGlobalFetch();
+		}
+	});
+	it('should not create a global', function () {
+		var safeFetch = require('../safe');
+		expect(typeof safeFetch).to.eql('function');
+		expect(typeof fetch).to.eql('undefined');
+	});
+});


### PR DESCRIPTION
This pull allows users of the library to do
```js
var fetch = require('isomorphic-fetch/safe');
require('assert')(typeof global.fetch === 'undefined');
```

'safe' requires do not result in any new global.fetch.

I'd like to use this library as a dependency in a lib I'm working on which, when run in the browser, should not touch global scope. This PR makes that use case possible without having to fork the lib.

Behavior of `require('isomorphic-fetch')` should remain unchanged (ie it will return the same thing and continue setting `global.fetch` on server and browser).