### PR TITLE
Ensure supporting classes are exported

### DIFF
--- a/fetch-npm-node.js
+++ b/fetch-npm-node.js
@@ -1,13 +1,29 @@
 "use strict";
 
 var realFetch = require('node-fetch');
-module.exports = function(url, options) {
-	if (/^\/\//.test(url)) {
-		url = 'https:' + url;
-	}
-	return realFetch.call(this, url, options);
-};
+
+function fetch(url, options) {
+    if (/^\/\//.test(url)) {
+        url = 'https:' + url;
+    }
+    return realFetch(url, options);
+}
+
+fetch.Response = realFetch.Response;
+fetch.Headers = realFetch.Headers;
+fetch.Request = realFetch.Request;
+
+module.exports = fetch;
 
 if (!global.fetch) {
-	global.fetch = module.exports;
+    global.fetch = fetch;
+}
+if (!global.Response) {
+    global.Response = fetch.Response;
+}
+if (!global.Headers) {
+    global.Headers = fetch.Headers;
+}
+if (!global.Request) {
+    global.Request = fetch.Request;
 }

--- a/fetch-npm-node.js
+++ b/fetch-npm-node.js
@@ -3,10 +3,10 @@
 var realFetch = require('node-fetch');
 
 function fetch(url, options) {
-    if (/^\/\//.test(url)) {
-        url = 'https:' + url;
-    }
-    return realFetch(url, options);
+	if (/^\/\//.test(url)) {
+		url = 'https:' + url;
+	}
+	return realFetch(url, options);
 }
 
 fetch.Response = realFetch.Response;
@@ -16,14 +16,14 @@ fetch.Request = realFetch.Request;
 module.exports = fetch;
 
 if (!global.fetch) {
-    global.fetch = fetch;
+	global.fetch = fetch;
 }
 if (!global.Response) {
-    global.Response = fetch.Response;
+	global.Response = fetch.Response;
 }
 if (!global.Headers) {
-    global.Headers = fetch.Headers;
+	global.Headers = fetch.Headers;
 }
 if (!global.Request) {
-    global.Request = fetch.Request;
+	global.Request = fetch.Request;
 }

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,4 +1,7 @@
-/*global fetch*/
+/*global fetch */
+/*global Response*/
+/*global Headers*/
+/*global Request*/
 "use strict";
 
 require('es6-promise').polyfill();
@@ -24,8 +27,20 @@ describe('fetch', function() {
 			.reply(404, bad);
 	});
 
-	it('should be defined', function() {
+	it('should expose fetch globally', function() {
 		expect(fetch).to.be.a('function');
+	});
+
+	it('should expose Response globally', function() {
+		expect(Response).to.be.a('function');
+	});
+
+	it('should expose Headers globally', function() {
+		expect(Headers).to.be.a('function');
+	});
+
+	it('should expose Request globally', function() {
+		expect(Request).to.be.a('function');
 	});
 
 	it('should facilitate the making of requests', function(done) {


### PR DESCRIPTION
This allows e.g. setting custom headers on the server
