### PR TITLE
Fixes Promise library replacement

### DIFF
--- a/fetch-npm-node.js
+++ b/fetch-npm-node.js
@@ -17,7 +17,7 @@ var isomorphicFetch = function(url, options) {
 module.exports = isomorphicFetch;
 
 if (!global.fetch) {
-	global.fetch = module.exports;
+	global.fetch = isomorphicFetch;
 	global.Response = realFetch.Response;
 	global.Headers = realFetch.Headers;
 	global.Request = realFetch.Request;

--- a/fetch-npm-node.js
+++ b/fetch-npm-node.js
@@ -1,12 +1,20 @@
 "use strict";
 
 var realFetch = require('node-fetch');
-module.exports = function(url, options) {
+
+var isomorphicFetch = function(url, options) {
 	if (/^\/\//.test(url)) {
 		url = 'https:' + url;
 	}
+
+	if (isomorphicFetch.Promise) {
+		realFetch.Promise = isomorphicFetch.Promise;
+	}
+
 	return realFetch.call(this, url, options);
 };
+
+module.exports = isomorphicFetch;
 
 if (!global.fetch) {
 	global.fetch = module.exports;

--- a/package.json
+++ b/package.json
@@ -23,10 +23,11 @@
     "whatwg-fetch": ">=0.10.0"
   },
   "devDependencies": {
+    "bluebird": "^3.0.5",
     "chai": "^1.10.0",
     "es6-promise": "^2.0.1",
     "jshint": "^2.5.11",
-    "lintspaces-cli": "0.0.4",
+    "lintspaces-cli": "^0.1.1",
     "mocha": "^2.1.0",
     "nock": "^0.56.0",
     "npm-prepublish": "^1.0.2"

--- a/test/api.promise.js
+++ b/test/api.promise.js
@@ -1,0 +1,30 @@
+/*global fetch*/
+"use strict";
+
+require('../fetch-npm-node');
+var expect = require('chai').expect;
+var nock = require('nock');
+var Bluebird = require('bluebird');
+
+function responseToText(response) {
+	if (response.status >= 400) throw new Error("Bad server response");
+	return response.text();
+}
+
+describe('fetch.Promise', function() {
+	before(function() {
+		fetch.Promise = Bluebird;
+
+		nock('https://mattandre.ws')
+			.get('/succeed.txt')
+			.reply(200);
+	});
+
+	it('should allow Promise library replacement', function() {
+		fetch('//mattandre.ws/succeed.txt')
+			.then(function (response) {
+				expect(global.Response.Promise).to.equal(Bluebird);
+				return response.text();
+			});
+	});
+});


### PR DESCRIPTION
Might this fix #43?

I added a test case without the `es6-promise` polyfill, instead setting `fetch.Promise` to use `bluebird`, and have been able to successfully test this on Node 0.10.

Let me know if you find anything amiss.
