### PR TITLE
Expose Headers, Response and Request constructor as exports

### DIFF
--- a/fetch-npm-node.js
+++ b/fetch-npm-node.js
@@ -10,7 +10,7 @@ module.exports = function(url, options) {
 
 if (!global.fetch) {
 	global.fetch = module.exports;
-	global.Response = realFetch.Response;
-	global.Headers = realFetch.Headers;
-	global.Request = realFetch.Request;
+	global.Response = module.exports.Response = realFetch.Response;
+	global.Headers = module.exports.Headers = realFetch.Headers;
+	global.Request = module.exports.Request = realFetch.Request;
 }


### PR DESCRIPTION
I'm now in two minds whether this should be done at all. In the browser I think no - isomorphic fetch should be fairly pure a fetch polyfill, in my [not particularly strong] opinion

In which case is it really a good idea to have a different API on the server?
