### PR TITLE
Add tip for compiling with webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ fetch('//offline-news-api.herokuapp.com/stories')
 	});
 ```
 
+### webpack
+
+If you're using webpack with `target: node` (e.g. for testing), you can avoid warnings about the dynamic `require` by adding the following to your configuration ([more info](andris9/encoding#16)):
+
+```js
+{
+  module: {
+    exprContextRegExp: /$^/,
+    exprContextCritical: false
+  }
+}
+```
+
 ## License
 
 All open source code released by FT Labs is licenced under the MIT licence.  Based on [the fine work by](https://github.com/github/fetch/pull/31) **[jxck](https://github.com/Jxck)**.


### PR DESCRIPTION
When you're compiling tests for Node, `isomorphic-fetch` will use `node-fetch`, which uses `encoding`, which [requires `iconv` dynamically](https://github.com/andris9/encoding/blob/91ae950aaa854a119122c27cdbabd8c5585106f7/lib/iconv-loader.js#L9), which causes warnings. This config addition will cause those `require`s to throw an error.

It can seem weird to compile tests with webpack for Node, but it makes sense when you want to run your tests in the command-line or when you want to use certain Node testing tools or when you're testing React code which will be rendering on the server…