### PR TITLE
Show ES6 alternative syntax for importing

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,13 @@ bower install --save isomorphic-fetch es6-promise
 ## Usage
 
 ```js
+// If using ES5
 require('es6-promise').polyfill();
 require('isomorphic-fetch');
+
+//If using ES6
+import { polyfill } from 'es6-promise';
+import 'isomorphic-fetch';
 
 fetch('//offline-news-api.herokuapp.com/stories')
 	.then(function(response) {


### PR DESCRIPTION
Some users may be new to using ES6. This change may provide a hint to those who are new to ES6 but would like to maintain as much ES6 syntax as possible.