### PR TITLE
Add React Native support

### DIFF
--- a/fetch-npm-react-native.js
+++ b/fetch-npm-react-native.js
@@ -1,3 +1,1 @@
-// Self is defined in Chrome Debugger, but not in JavaScriptCore
-var globalObject = typeof self === "undefined" ? global : self;
-module.exports = globalObject.fetch.bind(globalObject);
+module.exports = fetch;

--- a/fetch-npm-react-native.js
+++ b/fetch-npm-react-native.js
@@ -1,0 +1,4 @@
+// Self is defined in Chrome Debugger, but not in JavaScriptCore
+var globalObject = typeof self === "undefined" ? global : self;
+module.exports = globalObject.fetch.bind(globalObject);
+

--- a/fetch-npm-react-native.js
+++ b/fetch-npm-react-native.js
@@ -1,4 +1,3 @@
 // Self is defined in Chrome Debugger, but not in JavaScriptCore
 var globalObject = typeof self === "undefined" ? global : self;
 module.exports = globalObject.fetch.bind(globalObject);
-

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "description": "Isomorphic WHATWG Fetch API, for Node & Browserify",
   "browser": "fetch-npm-browserify.js",
+  "react-native": "fetch-npm-react-native.js",
   "main": "fetch-npm-node.js",
   "scripts": {
     "files": "find . -name '*.js' ! -path './node_modules/*' ! -path './bower_components/*'",


### PR DESCRIPTION
Specify a separate entry point for React Native that export React Native's `fetch()` polyfill. Would that be a more acceptable fix for #63?
