### PR TITLE
Fix "self is not defined" on Browserified bundle running Node

### DIFF
--- a/fetch-npm-browserify.js
+++ b/fetch-npm-browserify.js
@@ -2,9 +2,9 @@
 // on the global object (window or self)
 //
 // Return that as the export for use in Webpack, Browserify etc.
-if (typeof self != 'undefined') {
+if (typeof self !== 'undefined') {
 	require('whatwg-fetch');
 	module.exports = self.fetch.bind(self);
 } else {
-	module.exports = require('./fetch-npm-node')
+	module.exports = require('./fetch-npm-node');
 }

--- a/fetch-npm-browserify.js
+++ b/fetch-npm-browserify.js
@@ -2,5 +2,9 @@
 // on the global object (window or self)
 //
 // Return that as the export for use in Webpack, Browserify etc.
-require('whatwg-fetch');
-module.exports = self.fetch.bind(self);
+if (typeof self != 'undefined') {
+	require('whatwg-fetch');
+	module.exports = self.fetch.bind(self);
+} else {
+	module.exports = require('./fetch-npm-node')
+}


### PR DESCRIPTION
If you browserify a bundle that includes isomorphic-fetch, it only adds the client-side fetch (whatwg-fetch) to the bundle. 
As a result, when importing the browserified bundle via Node, it fails to import "fetch-npm-node" and throws the error "self is not defined".

Self cannot be assumed to be defined.

In reality, a check should also be made to see if `window` exists, but I intentionally made the PR as minimal as possible.