### PR TITLE
Update lintspaces-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "chai": "^1.10.0",
     "es6-promise": "^2.0.1",
     "jshint": "^2.5.11",
-    "lintspaces-cli": "0.0.4",
+    "lintspaces-cli": "^0.1.1",
     "mocha": "^2.1.0",
     "nock": "^0.56.0",
     "npm-prepublish": "^1.0.2"


### PR DESCRIPTION
On linux the older version crashes on install due to the use of a windows path in an old version of the `editorconfig` package.

Tests checked and passed.