### PR TITLE
Update node fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/matthew-andrews/isomorphic-fetch/issues",
   "dependencies": {
-    "node-fetch": "^1.0.1",
+    "node-fetch": "^1.7.1",
     "whatwg-fetch": ">=0.10.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The version of node fetch used is out of date and produces broken stack traces that do not include the error message. This fixes that issue.