### PR TITLE
Use same dependency name across the bower and npm files

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,6 @@
   "name": "isomorphic-fetch",
   "main": ["fetch-bower.js"],
   "dependencies": {
-    "fetch": "github/fetch#>=0.10.0"
+    "whatwg-fetch": "github/fetch#>=0.10.0"
   }
 }

--- a/fetch-bower.js
+++ b/fetch-bower.js
@@ -1,1 +1,1 @@
-module.exports = require('fetch');
+module.exports = require('whatwg-fetch');


### PR DESCRIPTION
Isomorphic fetch uses different dependencies when installed via npm vs bower.
Installing via npm will install [whatwg-fetch](https://github.com/matthew-andrews/isomorphic-fetch/blob/master/package.json#L23).
Installing via bower will install [fetch](https://github.com/matthew-andrews/isomorphic-fetch/blob/master/bower.json#L5).

When building the bundle using a [webpack configuration](https://github.com/Financial-Times/origami-build-tools/blob/master/config/webpack.config.js#L24) which will use bower.json over package.json, webpack will find the bower.json file for isomorphic-fetch and use the file referenced in the `main` field (fetch-bower) and use that as the file to bundle. [fetch-bower](https://github.com/matthew-andrews/isomorphic-fetch/blob/master/fetch-bower.js) is expecting a dependency named `fetch` to exist but it does not, the name of the dependency that was installed is `whatwg-fetch`. 

We can avoid this situation by aliasing the bower dependency to `whatwg-fetch`, which is the same name as the dependency that gets installed via npm.