### PR TITLE
Update node-fetch to `^2.0.0` (major change)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/matthew-andrews/isomorphic-fetch/issues",
   "dependencies": {
-    "node-fetch": "^1.0.1",
+    "node-fetch": "^2.0.0",
     "whatwg-fetch": ">=0.10.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This will change the behavior of `isomorphic-fetch` if imported in a
Node.js environment. The actual major changes can be found in the
`2.0.0` release notes of node-fetch.
See: https://github.com/bitinn/node-fetch/blob/master/CHANGELOG.md#v200

Overall, this should increase the usefulness of `isomorphic-fetch` by a lot since version 2 aligns the implementation with the spec for a lot of issues. For instance, I expect this to fix:
- [#96 – `.arrayBuffer()` is not supported](https://github.com/matthew-andrews/isomorphic-fetch/issues/96)
- [#68 – `headers.forEach`](https://github.com/matthew-andrews/isomorphic-fetch/issues/68)