### PR TITLE
fix: bump whatwg-fetch version to ^2

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/matthew-andrews/isomorphic-fetch/issues",
   "dependencies": {
     "node-fetch": "^1.0.1",
-    "whatwg-fetch": ">=0.10.0"
+    "whatwg-fetch": "^2.0.4"
   },
   "devDependencies": {
     "chai": "^1.10.0",


### PR DESCRIPTION
whatwg-fetch was updated to version 3 but there is actually [a "compatibility issue" with webpack](https://github.com/matthew-andrews/isomorphic-fetch/issues/174), this PR sets whatwg-fetch on a major version 2