### PR TITLE
Fix: realFetch.call is not a function

### DIFF
--- a/fetch-npm-node.js
+++ b/fetch-npm-node.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var realFetch = require('node-fetch');
+var realFetch = require('node-fetch').default;
 module.exports = function(url, options) {
 	if (/^\/\//.test(url)) {
 		url = 'https:' + url;


### PR DESCRIPTION
#194 
Fixed an error when building with Webpack.
 
Reproduction is available in the following repositories.
https://github.com/merutin/isomorphic-fetch-repro  

Please let me know if there are any necessary steps.