### PR TITLE
Bump node-fetch to 2.6.7 to resolve security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/matthew-andrews/isomorphic-fetch/issues",
   "dependencies": {
-    "node-fetch": "^2.6.1",
+    "node-fetch": "^2.6.7",
     "whatwg-fetch": "^3.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
See [here](https://security.snyk.io/vuln/SNYK-JS-NODEFETCH-2342118) and [here](https://github.com/node-fetch/node-fetch/pull/1453).

Addresses #202.